### PR TITLE
Compatibility to PHP 7

### DIFF
--- a/modules/ModuleMemberlist.php
+++ b/modules/ModuleMemberlist.php
@@ -67,7 +67,14 @@ class ModuleMemberlist extends \Module
 	 */
 	protected function compile()
 	{
-		$this->import('String');
+		if (!version_compare(VERSION, '3.5', '<'))
+		{
+			$this->import('StringUtil');
+		}
+		else 
+		{	
+			$this->import('String');
+		}
 		$this->loadDataContainer('tl_member');
 		$this->loadLanguageFile('tl_member');
 


### PR DESCRIPTION
To ensure the compatibility to PHP 7 it would be necessary to use the class StringUtil instead of String if the contao release >= 3.5 is used.
ChrMue