### PR TITLE
Load data container of tl_member

### DIFF
--- a/system/modules/memberlist/modules/ModuleMemberlist.php
+++ b/system/modules/memberlist/modules/ModuleMemberlist.php
@@ -86,19 +86,14 @@ class ModuleMemberlist extends \Module
 	 */
 	protected function listAllMembers()
 	{
+		\Contao\Controller::loadDataContainer('tl_member');
+
 		$arrSortedFields = array();
 
 		// Sort fields
 		foreach ($this->arrMlFields as $field)
 		{
-			if (isset($GLOBALS['TL_DCA']['tl_member']['fields'][$field]['label']))
-			{
-				$arrSortedFields[$field] = $GLOBALS['TL_DCA']['tl_member']['fields'][$field]['label'][0];
-			}
-			else
-			{
-				$arrSortedFields[$field] = $GLOBALS['TL_LANG']['tl_member'][$field][0];
-			}
+			$arrSortedFields[$field] = $GLOBALS['TL_DCA']['tl_member']['fields'][$field]['label'][0];
 		}
 
 		natcasesort($arrSortedFields);

--- a/system/modules/memberlist/modules/ModuleMemberlist.php
+++ b/system/modules/memberlist/modules/ModuleMemberlist.php
@@ -91,7 +91,14 @@ class ModuleMemberlist extends \Module
 		// Sort fields
 		foreach ($this->arrMlFields as $field)
 		{
-			$arrSortedFields[$field] = $GLOBALS['TL_LANG']['tl_member'][$field][0];
+			if (isset($GLOBALS['TL_DCA']['tl_member']['fields'][$field]['label']))
+			{
+				$arrSortedFields[$field] = $GLOBALS['TL_DCA']['tl_member']['fields'][$field]['label'][0];
+			}
+			else
+			{
+				$arrSortedFields[$field] = $GLOBALS['TL_LANG']['tl_member'][$field][0];
+			}
 		}
 
 		natcasesort($arrSortedFields);

--- a/system/modules/memberlist/modules/ModuleMemberlist.php
+++ b/system/modules/memberlist/modules/ModuleMemberlist.php
@@ -91,7 +91,7 @@ class ModuleMemberlist extends \Module
 		// Sort fields
 		foreach ($this->arrMlFields as $field)
 		{
-			$arrSortedFields[$field] = $GLOBALS['TL_DCA']['tl_member']['fields'][$field]['label'][0];
+			$arrSortedFields[$field] = $GLOBALS['TL_LANG']['tl_member'][$field][0];
 		}
 
 		natcasesort($arrSortedFields);


### PR DESCRIPTION
Fixes #17 

In newer Contao versions, you don't have to define a label for each DCA field any more. It will be automatically pulled from the translations, if not given. Currently this extension relies on the label in the DCA though and thus no label will be shown in the front end for the `<thead>` or the `<select>`.

The labels will only be present, if the data container is actually loaded beforehand.