### PR TITLE
small changes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Damit Contao-Erweiterungen, die eigene Feldtypen definieren die Möglichkeit hab
 
 memberListFormatValue
 ---------------------
-Der "memberListFormatValue"-Hook wird beim formatieren von Ausgabewerten für die Mitgliederliste ausgeführt. Er übergibt den Namen des Contao Mitgliedsfeldes, den Wert, der diesem Feld zugeordnet ist, ein Collection-Objekt mit den Mitgliedsdaten und einen booleschen Wert, der angibt, ob es sich bei der Ausgabe um einen einzelnen Mitgliedseintrag handelt, oder um einen Listeneintrag. Als Rückgabewert erwartet die Funktion einen String-Wert für die Frontendausgabe des Mitgliedsfeldes, oder wenn es sich nicht um das Feld handelt den booleschen Wert false, damit die reguläre Mitgliederlisten-Ausgabe durchgeführt wird.
+Der "memberListFormatValue"-Hook wird beim Formatieren von Ausgabewerten für die Mitgliederliste ausgeführt. Er übergibt den Namen des Contao Mitgliedsfeldes, den Wert, der diesem Feld zugeordnet ist, ein Collection-Objekt mit den Mitgliedsdaten und einen booleschen Wert, der angibt, ob es sich bei der Ausgabe um einen einzelnen Mitgliedseintrag handelt, oder um einen Listeneintrag.
+
+Als Rückgabewert erwartet die Funktion einen String-Wert für die Frontendausgabe des Mitgliedsfeldes, oder wenn es sich nicht um das Feld handelt, den booleschen Wert false, damit die reguläre Mitgliederlisten-Ausgabe durchgeführt wird.
 
 ```php
 // config.php


### PR DESCRIPTION
btw: den Satz

> Er übergibt den Namen des Contao Mitgliedsfeldes, den Wert, der diesem Feld zugeordnet ist, ein Collection-Objekt mit den Mitgliedsdaten und einen booleschen Wert, der angibt, ob es sich bei der Ausgabe um einen einzelnen Mitgliedseintrag handelt, oder um einen Listeneintrag.

würde ich in zwei aufteilen - ich verstehe leider nicht was da geschrieben steht, so dass ich den nicht umstellen kann ...