### PR TITLE
Fix - Check for Array-Key exists

### DIFF
--- a/system/modules/memberlist/dca/tl_member.php
+++ b/system/modules/memberlist/dca/tl_member.php
@@ -70,7 +70,7 @@ class tl_member_memberlist extends Backend
 				continue;
 			}
 
-			if ($v['eval']['feViewable'])
+			if (isset($v['eval']['feViewable']) && $v['eval']['feViewable'])
 			{
 				$return[$k] = $GLOBALS['TL_DCA']['tl_member']['fields'][$k]['label'][0];
 			}


### PR DESCRIPTION
Adding check for existence fo array key.  otherwise in Contao debug mode this will lead to a PHP warning.

[German]
Es sollte geprüft werden ob der Key "feViewable" auch wirklich existiert, da das ansonsten zu einer PHP-Warning im Contao Backend (Version 4.9 und neuer) beim Aufruf der Mitglieder-Verwaltung führt, wenn man den Debug-Modus eingeschaltet hat.

Nicht alle Felder von tl_member bzw. durch Erweiterungen und Co. hinzugefügte Felder haben  zwangsweise feViewable.